### PR TITLE
Add type property to help sdk api correctly map item_options

### DIFF
--- a/src/main/java/uk/gov/companieshouse/certificates/orders/api/model/CertificateItemOptions.java
+++ b/src/main/java/uk/gov/companieshouse/certificates/orders/api/model/CertificateItemOptions.java
@@ -2,12 +2,16 @@ package uk.gov.companieshouse.certificates.orders.api.model;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.gson.Gson;
+import org.springframework.data.annotation.Transient;
 
 /**
  * An instance of this represents the item options for a certificate item.
  */
 @JsonPropertyOrder(alphabetic = true)
 public class CertificateItemOptions {
+
+    @Transient
+    private final String type = "CertificateItemOptions";
 
     private CertificateType certificateType;
 
@@ -142,4 +146,5 @@ public class CertificateItemOptions {
     @Override
     public String toString() { return new Gson().toJson(this); }
 
+    public String getType() { return type; }
 }


### PR DESCRIPTION
This adds a `type` property that helps sdk api correctly identify `item_options` type.