### PR TITLE
Remove Spring Data REST

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 		<snakeyaml.version>1.25</snakeyaml.version>
 		<api-sdk-manager-java-library.version>1.0.2</api-sdk-manager-java-library.version>
 		<api-sdk-java.version>4.2.1</api-sdk-java.version>
-		<api-security-java.version>0.2.16</api-security-java.version>
+		<api-security-java.version>0.3.0</api-security-java.version>
 		<start-class>uk.gov.companieshouse.certificates.orders.api.CertificatesApiApplication</start-class>
 		<!-- Test -->
 		<junit-jupiter-engine-version>5.4.2</junit-jupiter-engine-version>
@@ -71,11 +71,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-rest</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.data</groupId>
-			<artifactId>spring-data-rest-hal-browser</artifactId>
+			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/uk/gov/companieshouse/certificates/orders/api/repository/CertificateItemRepository.java
+++ b/src/main/java/uk/gov/companieshouse/certificates/orders/api/repository/CertificateItemRepository.java
@@ -1,8 +1,9 @@
 package uk.gov.companieshouse.certificates.orders.api.repository;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
 import uk.gov.companieshouse.certificates.orders.api.model.CertificateItem;
 
-@RepositoryRestResource
+@Repository
 public interface CertificateItemRepository extends MongoRepository<CertificateItem, String> { }


### PR DESCRIPTION
Using `@RepositoryRestResource` is generating a separate set of endpoints that we do not want to expose so removing the Spring Data REST dependency and keep just our defined endpoints.
Upgrade `api-security-java.version` to latest version to fix dependency issues caused by transitive dependencies after removing Spring Data REST