### PR TITLE
DEBT-1607 Upgrade to structured-logging v1.9.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-		<structured-logging.version>1.9.10</structured-logging.version>
+		<structured-logging.version>1.9.12</structured-logging.version>
 		<api-helper-java.version>1.1.0-rc1</api-helper-java.version>
 		<commons.lang.version>2.6</commons.lang.version>
 		<commons.beanutils.version>1.9.4</commons.beanutils.version>
@@ -232,23 +232,6 @@
 			<artifactId>powermock-api-mockito2</artifactId>
 			<version>${powermock.version}</version>
 			<scope>test</scope>
-		</dependency>
-
-		<!-- Override log4j versions -->
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>2.15.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>2.15.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-to-slf4j</artifactId>
-			<version>2.15.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
- Upgrade to structured-logging v1.9.12
- Log4J dependency removed

[dependency-tree.txt](https://github.com/companieshouse/certificates.orders.api.ch.gov.uk/files/7762395/dependency-tree.txt)

Relates to: [Upgrade certificates.orders.api.ch.gov.uk to 2.17 and 1.9.12](https://companieshouse.atlassian.net/browse/DEBT-1607)
